### PR TITLE
Minor Fix: Maybe a Typo

### DIFF
--- a/dtv.py
+++ b/dtv.py
@@ -214,7 +214,7 @@ class main(QMainWindow):
         # If user selected a file then process it...
         if fileName:
             # Resolve symlinks
-            filename = os.path.realpath(fileName)
+            fileName = os.path.realpath(fileName)
 
             self.ui.setWindowTitle("DTV - " + fileName)
 


### PR DESCRIPTION
Maybe a typo.
At line 217:

https://github.com/bmx666/dtv-demo/blob/1ebe2f6aaa16991d29c18c42525ad1166768b9a4/dtv.py#L212-L218

**It stores the resolved file path in a different variable, then using the old variable** (which maybe a link to file in a correct arch/*/... directory causes Exception at line (comment above line):

https://github.com/bmx666/dtv-demo/blob/1ebe2f6aaa16991d29c18c42525ad1166768b9a4/dtv.py#L227-L228

![image](https://user-images.githubusercontent.com/37269665/147259111-15fa3ae0-54c4-45ce-92df-eff0a04c19e5.png)

> Possible usecase:
> I had a link `/tmp/dts` to `linux/arch/arm/boot/dts`, so to quickly navigate to it
> Actually I wanted it to open the file chosing dialog to open same directory, trying on that also 😅