### PR TITLE
Draft PR: Recently opened files; And opening repeat file dialogs in same directory

### DIFF
--- a/dtv.py
+++ b/dtv.py
@@ -12,7 +12,10 @@ import sys
 import tempfile
 import time
 
-from xdg import BaseDirectory
+try:
+    from xdg import BaseDirectory
+except:
+    print("Couldn't Import xdg (Not an error")
 
 from includetree import includeTree
 from helper import loadConfig, annotateDTS
@@ -205,8 +208,14 @@ class Main(QMainWindow):
             self.openDTSFile(sys.argv[1])
 
     # Returns a dictionary, schema: {filename(str): timestamp(number)}
+    # To get array of filenames, in order from newest (at index 0) to oldest, just use getRecentFilenames().values(), then .reverse()... It will NOT throw :)
     def getRecentFilenames():
-        cache_dir = BaseDirectory.save_cache_path("device-tree-visualiser")
+        try:
+            cache_dir = BaseDirectory.save_cache_path("device-tree-visualiser")
+        except:
+            print("Using current directory for temporary files", file=sys.stderr)
+            cache_dir = os.path.curdir
+
         recents = {}
         try:
             with open( str(os.path.join(cache_dir, "recent.list")) ) as file:
@@ -227,8 +236,12 @@ class Main(QMainWindow):
     def pushToRecentFilenames(filename):
         timestamp = int(time.time())
 
-        # TODO: Handle case for Windows
-        cache_dir = BaseDirectory.save_cache_path("device-tree-visualiser")
+        try:
+            cache_dir = BaseDirectory.save_cache_path("device-tree-visualiser")
+        except:
+            print("Using current directory for temporary files", file=sys.stderr)
+            cache_dir = os.path.curdir
+
         recents_filepath = os.path.join(cache_dir, "recent.list")
 
         # just 'touch' the file

--- a/dtv.py
+++ b/dtv.py
@@ -11,6 +11,8 @@ from subprocess import PIPE
 import sys
 import tempfile
 
+from xdg import BaseDirectory
+
 from includetree import includeTree
 from helper import loadConfig, annotateDTS
 
@@ -174,8 +176,8 @@ def center(window):
 
     # Determine the center of mainwindow
     centerPoint = QtCore.QPoint()
-    centerPoint.setX(main.x() + (main.width()/2))
-    centerPoint.setY(main.y() + (main.height()/2))
+    centerPoint.setX(Main.x() + (Main.width()/2))
+    centerPoint.setY(Main.y() + (Main.height()/2))
 
     # Calculate the current window's top-left such that
     # its center co-incides with the mainwindow's center
@@ -185,7 +187,7 @@ def center(window):
     # Align current window as per above calculations
     window.move(frameGm.topLeft())
 
-class main(QMainWindow):
+class Main(QMainWindow):
 
 
     def __init__(self):
@@ -199,6 +201,26 @@ class main(QMainWindow):
 
         if len(sys.argv) > 1:
             self.openDTSFile(sys.argv[1])
+
+    def getRecentFilenames():
+        cache_dir = BaseDirectory.save_cache_path("device-tree-visualiser")
+        try:
+            file = open( os.path.join(cache_dir, "recent.list") )
+            return file.readlines()
+        except:
+            return []
+
+    def pushToRecentFilenames(filename):
+        cache_dir = BaseDirectory.save_cache_path("device-tree-visualiser")
+        with open( os.path.join(cache_dir, "recent.list"), 'a' ) as file:
+            try:
+                # If filename is not a relative/absolute path to existing file
+                # this may fail
+                filepath = os.path.realpath(filename)
+                file.write(filepath + '\n')
+            except:
+                print("WARNING: Invalid or non existent file passed to"
+                    "pushToRecentFilenames: ", filename, file=sys.stderr)
 
     def openDTSFileUI(self):
 
@@ -385,10 +407,12 @@ except subprocess.CalledProcessError as e:
 
 app = QApplication(sys.argv)
 
-main = main()
+main = Main()
 
 # Blocks till Qt app is running, returns err code if any
 qtReturnVal = app.exec_()
+
+#Main.pushToRecentFilenames("screenshot/dtv-demo_dtc_original.png")
 
 sys.exit(qtReturnVal)
 


### PR DESCRIPTION
It's **not done**, though as said in title, I tried adding a menu option in File, just below Open File, like this, where Recently Opened should be a dropdown like in VS Code's and others Open Recent options, but haven't programmed in qt, tried but didnt find much help in qt docs:

<img width="40%" src="https://user-images.githubusercontent.com/37269665/147281412-23d490e6-88d7-494a-80ee-6df2504c3cd0.png" />

Also the `xdg` dependency isn't needed, either we can do:
1. Just create and use '~/.config/device-tree-visualiser', instead of `BaseDirectory.save_cache_path("device-tree-visualiser")`
2. or use current directory for the recents.list file

I will just leave it here, you may just close it. Though have a look at https://github.com/adi-g15/dtv-demo/commit/1025c8c2257bc375120efe992d70cbdcc0963932, it's mergeable too, for eg. if I opened a dts file from "/home/adityag/os_projects/rpi_linux/arch/arm64/boot/dts/broadcom", and **using Open File option once more, I think it's more convenient for the application to open in the same dir**, so I may decide to go up a directory maybe or chose another in same dir, but easier than going again.
 Just my view, I forked already. Thanks a lot for the application, it helped me in learning and seeing some dts myself (visually much better) :+1:   
 